### PR TITLE
Add a cx_Freeze build script to create a Win32 executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+import sys
+from cx_Freeze import setup, Executable
+
+# Run python setup.py build to create the exe
+
+base = None
+if sys.platform == "win32":
+    base = "Win32GUI"
+
+setup(name = "ahCalculator",
+      version = "0.02",
+      description = "Diablo 3 auction house calculator",
+      executables = [Executable("ahCalculator.pyw", base=base)])
+


### PR DESCRIPTION
Needs the cx_Freeze dev version (tip) from https://bitbucket.org/anthony_tuininga/cx_freeze/downloads, otherwise it tosses Tcl/Tk errors.
